### PR TITLE
Adicionar testes com pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Color Palette Extractor
+
+Este projeto extrai uma paleta de cores de uma imagem utilizando k-means.
+
+## Como rodar os testes
+
+1. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Execute os testes com pytest na raiz do repositório:
+   ```bash
+   pytest
+   ```

--- a/palette.py
+++ b/palette.py
@@ -4,18 +4,31 @@ from sklearn.cluster import KMeans
 import sys
 
 def extrair_cores(imagem, n_cores=5):
+    """Extrai uma paleta de cores de uma imagem.
+
+    Retorna uma lista de cores em formato hexadecimal.
+    """
+
+    if not isinstance(n_cores, int) or n_cores <= 0:
+        raise ValueError("n_cores deve ser um inteiro positivo")
+
     img = Image.open(imagem).convert('RGB')
     img = img.resize((200, 200))
     pixels = np.array(img).reshape(-1, 3)
     kmeans = KMeans(n_clusters=n_cores, n_init="auto")
     kmeans.fit(pixels)
     cores = kmeans.cluster_centers_.astype(int)
+
+    hex_cores = []
     for cor in cores:
         r, g, b = cor
-        print(f'#{r:02x}{g:02x}{b:02x}')
+        hex_cores.append(f"#{r:02x}{g:02x}{b:02x}")
+
+    return hex_cores
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         print("Uso: python palette.py imagem.jpg")
     else:
-        extrair_cores(sys.argv[1])
+        for cor in extrair_cores(sys.argv[1]):
+            print(cor)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pillow
 numpy
 scikit-learn
+pytest

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -1,0 +1,21 @@
+import re
+import pytest
+from palette import extrair_cores
+
+
+def test_extrair_cores_returns_hex_strings():
+    cores = extrair_cores('1.PNG', n_cores=3)
+    assert len(cores) == 3
+    for cor in cores:
+        assert re.match(r'^#[0-9a-fA-F]{6}$', cor)
+
+
+def test_imagem_inexistente():
+    with pytest.raises(FileNotFoundError):
+        extrair_cores('imagem_inexistente.png')
+
+
+@pytest.mark.parametrize('valor', [0, -1, 2.5])
+def test_n_cores_invalido(valor):
+    with pytest.raises(ValueError):
+        extrair_cores('1.PNG', n_cores=valor)


### PR DESCRIPTION
## Summary
- ajustar `extrair_cores` para retornar lista de cores
- criar testes utilizando `pytest`
- adicionar instruções de execução dos testes no README
- incluir `pytest` nas dependências

## Testing
- `pip install -r requirements.txt` *(falhou: Could not find a version that satisfies the requirement pillow)*
- `pytest -q` *(falhou: command not found)*