### PR TITLE
Update scikit-learn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pillow
 numpy
-scikit-learn
+scikit-learn>=1.2


### PR DESCRIPTION
## Summary
- require `scikit-learn>=1.2` to support `n_init="auto"`

## Testing
- `git status --short`