### PR TITLE
Fix color value rounding

### DIFF
--- a/palette.py
+++ b/palette.py
@@ -9,7 +9,7 @@ def extrair_cores(imagem, n_cores=5):
     pixels = np.array(img).reshape(-1, 3)
     kmeans = KMeans(n_clusters=n_cores, n_init="auto")
     kmeans.fit(pixels)
-    cores = kmeans.cluster_centers_.astype(int)
+    cores = np.clip(np.rint(kmeans.cluster_centers_), 0, 255).astype(int)
     for cor in cores:
         r, g, b = cor
         print(f'#{r:02x}{g:02x}{b:02x}')


### PR DESCRIPTION
## Summary
- round and clip KMeans cluster centers to 0-255 before converting to integers

## Testing
- `python -m py_compile palette.py`
