### PR TITLE
Add random_state option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Por exemplo, usando a imagem de exemplo fornecida (`1.PNG`):
 python palette.py 1.PNG
 ```
 
+### Saída determinística
+
+Para obter os mesmos resultados em execuções subsequentes, forneça um
+`random_state` para o KMeans:
+
+```bash
+python palette.py 1.PNG -r 42
+python palette.py 1.PNG -r 42
+```
+
+As cores impressas serão as mesmas nas duas execuções.
+
 O script exibirá as cores encontradas em formato hexadecimal, uma por linha.
 
 ## Objetivo do projeto

--- a/palette.py
+++ b/palette.py
@@ -2,8 +2,9 @@ from PIL import Image, UnidentifiedImageError
 import numpy as np
 from sklearn.cluster import KMeans
 import argparse
+import sys
 
-def extrair_cores(imagem, n_cores=5):
+def extrair_cores(imagem, n_cores=5, random_state=None):
     try:
         img = Image.open(imagem).convert('RGB')
     except (FileNotFoundError, UnidentifiedImageError, OSError):
@@ -18,7 +19,7 @@ def extrair_cores(imagem, n_cores=5):
             f"Ajustando para {n_cores_max}."
         )
         n_cores = n_cores_max
-    kmeans = KMeans(n_clusters=n_cores, n_init="auto")
+    kmeans = KMeans(n_clusters=n_cores, n_init="auto", random_state=random_state)
     kmeans.fit(pixels)
     cores = np.clip(np.rint(kmeans.cluster_centers_), 0, 255).astype(int)
     for cor in cores:
@@ -34,6 +35,10 @@ if __name__ == '__main__':
         '-n', '--num-cores', type=int, default=5,
         help='N\u00famero de cores desejado.'
     )
+    parser.add_argument(
+        '-r', '--random-state', type=int, default=None,
+        help='Valor para o random_state do KMeans.'
+    )
     args = parser.parse_args()
 
-    extrair_cores(args.imagem, args.num_cores)
+    extrair_cores(args.imagem, args.num_cores, args.random_state)


### PR DESCRIPTION
## Summary
- add `--random-state` option to palette CLI
- pass the value to `KMeans`
- document deterministic example in README

## Testing
- `python -m py_compile palette.py`
