### PR TITLE
Validate color count

### DIFF
--- a/palette.py
+++ b/palette.py
@@ -2,6 +2,7 @@ from PIL import Image, UnidentifiedImageError
 import numpy as np
 from sklearn.cluster import KMeans
 import argparse
+import sys
 
 def extrair_cores(imagem, n_cores=5):
     try:
@@ -11,6 +12,12 @@ def extrair_cores(imagem, n_cores=5):
         sys.exit(1)
     img = img.resize((200, 200))
     pixels = np.array(img).reshape(-1, 3)
+    if n_cores < 1:
+        print(
+            "N\u00famero de cores deve ser no m\u00ednimo 1.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     n_cores_max = len(np.unique(pixels, axis=0))
     if n_cores > n_cores_max:
         print(


### PR DESCRIPTION
## Summary
- validate `n_cores` before use
- exit with a helpful message when the color count is invalid

## Testing
- `python -m py_compile palette.py`