### PR TITLE
Enable automatic browser launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Execute:
 python web_ui.py
 ```
 
-Uma página será aberta exibindo um seletor de imagem e o número de cores desejado. Após enviar a imagem, as cores extraídas aparecerão na tela.
+O navegador padrão será aberto automaticamente, exibindo um seletor de imagem e o número de cores desejado. Após enviar a imagem, as cores extraídas aparecerão na tela.
 
 ## Uso simplificado no Windows
 

--- a/web_ui.py
+++ b/web_ui.py
@@ -20,7 +20,7 @@ def main():
         saida = gr.HTML()
         executar = gr.Button("Extrair Cores")
         executar.click(gerar_paleta, [entrada_imagem, entrada_num_cores], saida)
-    demo.launch()
+    demo.launch(inbrowser=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add automatic browser opening when starting `web_ui.py`
- clarify in the README that the interface opens automatically

## Testing
- `python -m py_compile palette.py web_ui.py`
- `python web_ui.py` *(fails: ModuleNotFoundError: No module named 'gradio')*