### PR TITLE
Fix duplicate dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy
 scikit-learn>=1.4
 gradio
 matplotlib
-matplotlib


### PR DESCRIPTION
## Summary
- remove the duplicate `matplotlib` line in `requirements.txt`

## Testing
- `pytest -q` *(fails: No module named pytest)*