### PR TITLE
Fix favoritos_html initialization

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -101,7 +101,9 @@ def atualizar_programa():
 def main():
     with gr.Blocks() as demo:
         gr.Markdown("## Color Palette Extractor")
-        with gr.Tabs():
+        with gr.Tabs(selected=1):
+            with gr.Tab("Favoritas"):
+                favoritos_html = gr.HTML(gerar_html_favoritos())
             with gr.Tab("Extrair"):
                 with gr.Row():
                     entrada_imagem = gr.Image(type="filepath", label="Imagem")
@@ -131,8 +133,7 @@ def main():
                     [status_fav, favoritos_html],
                 )
                 atualizar.click(atualizar_programa, outputs=status)
-            with gr.Tab("Favoritas"):
-                favoritos_html = gr.HTML(gerar_html_favoritos())
+
     demo.launch(inbrowser=True)
 
 


### PR DESCRIPTION
## Summary
- create `favoritos_html` in the "Favoritas" tab before registering events
- keep the "Extrair" tab outputting updates to this component

## Testing
- `python -m py_compile web_ui.py`
- `python - <<'PY'
import sys, types
mods = {}
mods['gradio'] = types.ModuleType('gradio')
class B:
    def __enter__(self): return self
    def __exit__(self, *a): return False
    def click(self, *a, **k): pass
mods['gradio'].Blocks = B
mods['gradio'].HTML = B
mods['gradio'].Image = B
mods['gradio'].Slider = B
mods['gradio'].State = B
mods['gradio'].Textbox = B
mods['gradio'].Button = B
mods['gradio'].Tabs = B
mods['gradio'].Row = B
mods['gradio'].Tab = B
mods['gradio'].Markdown = lambda *a, **k: None
mods['palette'] = types.ModuleType('palette')
mods['palette'].extrair_cores_percentual = lambda *a, **k: (['#fff'], [1])
mods['palette'].save_palette = lambda *a, **k: None
mods['matplotlib'] = types.ModuleType('matplotlib')
mods['matplotlib'].pyplot = types.SimpleNamespace(subplots=lambda: (object(), object()), close=lambda *a, **k: None)
mods['PIL'] = types.ModuleType('PIL')
mods['PIL'].Image = types.SimpleNamespace(open=lambda *a, **k: None)
sys.modules.update(mods)
import web_ui
web_ui.main()
PY`