### PR TITLE
Fix git update path detection

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -8,7 +8,21 @@ import subprocess
 import os
 import json
 
+REPO_DIR = os.path.dirname(os.path.abspath(__file__))
+
 FAVORITES_FILE = "favorites.json"
+
+
+def find_git_root(start_path: str) -> str | None:
+    """Retorna o caminho do repositório Git mais próximo ou ``None``."""
+    path = os.path.abspath(start_path)
+    while True:
+        if os.path.isdir(os.path.join(path, ".git")):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            return None
+        path = parent
 
 
 def carregar_favoritos():
@@ -138,10 +152,13 @@ def salvar_paleta_sobre_imagem(caminho, imagem, cores, pos):
 
 def atualizar_programa():
     """Tenta atualizar o repositório local executando `git pull`."""
-    if not os.path.isdir(".git"):
+    repo_dir = find_git_root(REPO_DIR)
+    if repo_dir is None:
         return "Repositório Git não encontrado."
     try:
-        result = subprocess.run(["git", "pull"], capture_output=True, text=True)
+        result = subprocess.run(
+            ["git", "pull"], cwd=repo_dir, capture_output=True, text=True
+        )
         if result.returncode == 0:
             return "Atualização concluída:\n" + result.stdout
         return "Erro ao atualizar:\n" + result.stderr


### PR DESCRIPTION
## Summary
- locate the repo directory reliably
- walk up directories looking for `.git`
- use new path detection when updating the repo

## Testing
- `python -m py_compile web_ui.py`